### PR TITLE
Fix for 0.25 - Move the cache loading outside Awake

### DIFF
--- a/ActiveTextureManagement/ActiveTextureManagement.cs
+++ b/ActiveTextureManagement/ActiveTextureManagement.cs
@@ -89,6 +89,7 @@ namespace ActiveTextureManagement
         static int gcCount = 0;
         static long memorySaved = 0;
         static bool DBL_LOG = false;
+        static bool loadedTexturesCache = false;
         
         const int GC_COUNT_TRIGGER = 20;
         
@@ -114,13 +115,7 @@ namespace ActiveTextureManagement
 
         protected void Awake()
         {
-            if(HighLogic.LoadedScene == GameScenes.LOADING)
-            {
-                PopulateConfig();
-                LoadTextures();
-                
-            }
-            else if (HighLogic.LoadedScene == GameScenes.MAINMENU && !Compressed)
+            if (HighLogic.LoadedScene == GameScenes.MAINMENU && !Compressed)
             {
                 Update();
                 Compressed = true;
@@ -148,12 +143,18 @@ namespace ActiveTextureManagement
             }
         }
 
-        private void LoadTextures(){
-            UrlDir.UrlConfig[] INTERNALS = GameDatabase.Instance.GetConfigs("ACTIVE_TEXTURE_MANAGER");
-            UrlDir.UrlConfig node = INTERNALS[0];
+        private void LoadTextures()
+        {
+            if (loadedTexturesCache)
+                return;
+
+            int count = GameDatabase.Instance.root.AllFiles.Count(file => file.fileType == UrlDir.FileType.Texture);
+            if (count == 0)
+                return;
+
             {
                 List<UrlDir.UrlFile> FilesToRemove = new List<UrlDir.UrlFile>();
-                foreach (var file in node.parent.root.AllFiles)
+                foreach (var file in GameDatabase.Instance.root.AllFiles)
                 {
                     if (file.fileType == UrlDir.FileType.Texture && foldersList.Exists(n => file.url.StartsWith(n)))
                     {
@@ -170,8 +171,8 @@ namespace ActiveTextureManagement
                 }
                 LastTextureIndex = GameDatabase.Instance.databaseTexture.Count - 1;
             }
-            
-	    }
+            loadedTexturesCache = true;
+        }
 
         private GUISkin _mySkin;
         private Rect _mainWindowRect = new Rect(5, 5, 640, 240);
@@ -245,6 +246,9 @@ namespace ActiveTextureManagement
         protected void Update()
         {
             PopulateConfig();
+            
+            LoadTextures();
+
             if (!Compressed && GameDatabase.Instance.databaseTexture.Count > 0)
             {
                 int LocalLastTextureIndex = GameDatabase.Instance.databaseTexture.Count-1;


### PR DESCRIPTION
In Awake the Database seems to not be fully init and no file will have fileType = FileType.Texture
It works if pushed in the first Update.
