### PR TITLE
Update config.cfg to add override for Agencies

### DIFF
--- a/GameData/ActiveTextureManagement/config.cfg
+++ b/GameData/ActiveTextureManagement/config.cfg
@@ -83,6 +83,15 @@ OVERRIDES
 		scale = 1
 		max_size = 0
 	}
+	
+	.*/Agencies/.*
+	{
+		compress = false
+		mipmaps = false
+		scale = 1
+		max_size = 0
+		make_not_readable = false
+	}
 }
 
 ### Specific sections can be added in config files


### PR DESCRIPTION
Compressing agency icons caused contracts not to load for me, which also caused other UI issues in the main space center scene. (Not being able to enter certain buildings, not being able to exit others.) Adding this override to skip the Agencies folders by default resolved this for me.
