### PR TITLE
Skip Agencies by default

### DIFF
--- a/Content/basic/GameData/BoulderCo/ActiveTextureManagerConfig.cfg
+++ b/Content/basic/GameData/BoulderCo/ActiveTextureManagerConfig.cfg
@@ -82,6 +82,14 @@ OVERRIDES
 		scale = 1
 		max_size = 0
 	}
+	.*/Agencies/.*
+	{
+		compress = false
+		mipmaps = false
+		scale = 1
+		max_size = 0
+		make_not_readable = false
+	}
 }
 
 ### Specific sections can be added in config files


### PR DESCRIPTION
This is included in the Aggressive config, but got missed in Basic.
