### PR TITLE
Fix mipmapping of many icons

### DIFF
--- a/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/000_Toolbar.cfg
+++ b/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/000_Toolbar.cfg
@@ -7,7 +7,7 @@ ACTIVE_TEXTURE_MANAGER_CONFIG
 		000_Toolbar/.*
 		{
 			compress = true
-			mipmaps = true
+			mipmaps = false
 			scale = 1
 			max_size = 0
 		}

--- a/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/BetterTimeWarp.cfg
+++ b/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/BetterTimeWarp.cfg
@@ -1,10 +1,10 @@
 ACTIVE_TEXTURE_MANAGER_CONFIG
 {
-folder = RealChute
+folder = BetterTimeWarp
 enabled = true
 OVERRIDES
 {
-RealChute/Plugins/PluginData/.*
+BetterTimeWarp/Icons/.*
 {
 compress = true
 mipmaps = false

--- a/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/DiazoHorizVert.cfg
+++ b/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/DiazoHorizVert.cfg
@@ -1,10 +1,10 @@
 ACTIVE_TEXTURE_MANAGER_CONFIG
 {
-folder = RealChute
+folder = Diazo
 enabled = true
 OVERRIDES
 {
-RealChute/Plugins/PluginData/.*
+Diazo/.*/.*
 {
 compress = true
 mipmaps = false

--- a/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/FerramAerospaceResearch.cfg
+++ b/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/FerramAerospaceResearch.cfg
@@ -1,10 +1,10 @@
 ACTIVE_TEXTURE_MANAGER_CONFIG
 {
-folder = RealChute
+folder = FerramAerospaceResearch
 enabled = true
 OVERRIDES
 {
-RealChute/Plugins/PluginData/.*
+FerramAerospaceResearch/Textures/.*
 {
 compress = true
 mipmaps = false

--- a/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/FilterExtensions.cfg
+++ b/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/FilterExtensions.cfg
@@ -1,10 +1,10 @@
 ACTIVE_TEXTURE_MANAGER_CONFIG
 {
-folder = RealChute
+folder = 000_FilterExtensions
 enabled = true
 OVERRIDES
 {
-RealChute/Plugins/PluginData/.*
+000_FilterExtensions/Icons/.*
 {
 compress = true
 mipmaps = false

--- a/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/MechJeb2.cfg
+++ b/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/MechJeb2.cfg
@@ -1,10 +1,10 @@
 ACTIVE_TEXTURE_MANAGER_CONFIG
 {
-folder = RealChute
+folder = MechJeb2
 enabled = true
 OVERRIDES
 {
-RealChute/Plugins/PluginData/.*
+MechJeb2/Icons/.*
 {
 compress = true
 mipmaps = false

--- a/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/NavHud.cfg
+++ b/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/NavHud.cfg
@@ -1,10 +1,10 @@
 ACTIVE_TEXTURE_MANAGER_CONFIG
 {
-folder = RealChute
+folder = NavHud
 enabled = true
 OVERRIDES
 {
-RealChute/Plugins/PluginData/.*
+NavHud/*.png
 {
 compress = true
 mipmaps = false

--- a/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/NavyFishDPAI.cfg
+++ b/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/NavyFishDPAI.cfg
@@ -1,10 +1,10 @@
 ACTIVE_TEXTURE_MANAGER_CONFIG
 {
-folder = RealChute
+folder = NavyFish
 enabled = true
 OVERRIDES
 {
-RealChute/Plugins/PluginData/.*
+NavyFish/Plugins/ToolbarIcons/.*
 {
 compress = true
 mipmaps = false

--- a/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/PlanetShine.cfg
+++ b/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/PlanetShine.cfg
@@ -1,10 +1,10 @@
 ACTIVE_TEXTURE_MANAGER_CONFIG
 {
-folder = RealChute
+folder = PlanetShine
 enabled = true
 OVERRIDES
 {
-RealChute/Plugins/PluginData/.*
+PlanetShine/Icons/.*
 {
 compress = true
 mipmaps = false

--- a/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/RavienCritTempGauge.cfg
+++ b/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/RavienCritTempGauge.cfg
@@ -1,10 +1,10 @@
 ACTIVE_TEXTURE_MANAGER_CONFIG
 {
-folder = RealChute
+folder = Ravien
 enabled = true
 OVERRIDES
 {
-RealChute/Plugins/PluginData/.*
+Ravien/Textures/.*
 {
 compress = true
 mipmaps = false

--- a/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/SCANsat.cfg
+++ b/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/SCANsat.cfg
@@ -4,7 +4,7 @@ folder = SCANsat
 enabled = true
 OVERRIDES
 {
-SCANsat/Icons/*
+SCANsat/Icons/.*
 {
 compress = true
 mipmaps = false

--- a/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/Sentinel.cfg
+++ b/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/Sentinel.cfg
@@ -1,10 +1,10 @@
 ACTIVE_TEXTURE_MANAGER_CONFIG
 {
-folder = RealChute
+folder = KSEA
 enabled = true
 OVERRIDES
 {
-RealChute/Plugins/PluginData/.*
+KSEA/Sentinel/Textures/.*
 {
 compress = true
 mipmaps = false

--- a/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/ShipManifest.cfg
+++ b/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/ShipManifest.cfg
@@ -1,10 +1,10 @@
 ACTIVE_TEXTURE_MANAGER_CONFIG
 {
-folder = RealChute
+folder = ShipManifest
 enabled = true
 OVERRIDES
 {
-RealChute/Plugins/PluginData/.*
+ShipManifest/Images/.*
 {
 compress = true
 mipmaps = false

--- a/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/SwitchVessel.cfg
+++ b/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/SwitchVessel.cfg
@@ -1,10 +1,10 @@
 ACTIVE_TEXTURE_MANAGER_CONFIG
 {
-folder = RealChute
+folder = SwitchVessel
 enabled = true
 OVERRIDES
 {
-RealChute/Plugins/PluginData/.*
+SwitchVessel/*.png
 {
 compress = true
 mipmaps = false

--- a/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/ThunderAerospaceTACLS.cfg
+++ b/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/ThunderAerospaceTACLS.cfg
@@ -1,10 +1,10 @@
 ACTIVE_TEXTURE_MANAGER_CONFIG
 {
-folder = RealChute
+folder = ThunderAerospace/TacLifeSupport
 enabled = true
 OVERRIDES
 {
-RealChute/Plugins/PluginData/.*
+ThunderAerospace/TacLifeSupport/Textures/.*
 {
 compress = true
 mipmaps = false

--- a/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/WaypointManager.cfg
+++ b/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/WaypointManager.cfg
@@ -1,10 +1,10 @@
 ACTIVE_TEXTURE_MANAGER_CONFIG
 {
-folder = RealChute
+folder = WaypointManager
 enabled = true
 OVERRIDES
 {
-RealChute/Plugins/PluginData/.*
+WaypointManager/icons/.*
 {
 compress = true
 mipmaps = false

--- a/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/kOS.cfg
+++ b/Content/common/GameData/ActiveTextureManagement/ActiveTextureManagerConfigs/kOS.cfg
@@ -1,10 +1,10 @@
 ACTIVE_TEXTURE_MANAGER_CONFIG
 {
-folder = RealChute
+folder = kOS
 enabled = true
 OVERRIDES
 {
-RealChute/Plugins/PluginData/.*
+kOS/GFX/.*
 {
 compress = true
 mipmaps = false


### PR DESCRIPTION
This adds or modifies configuration files to suppress mipmapping of
icons on 18 mods. Many of these only go blurry if KSP's texture quality
is set to half-size not full-size.

Where I have had to name a configuration file, I've tried to use something
related to the name of the mod, but also the name of the directory in
GameData it lives in (if that is unrelated to the name of the mod).